### PR TITLE
Added 'mouseleave' event listener

### DIFF
--- a/shapes.js
+++ b/shapes.js
@@ -117,6 +117,9 @@ function CanvasState(canvas) {
   canvas.addEventListener('mouseup', function(e) {
     myState.dragging = false;
   }, true);
+  canvas.addEventListener('mouseleave', function(e) {
+    myState.dragging = false;
+  });
   // double click for making new shapes
   canvas.addEventListener('dblclick', function(e) {
     var mouse = myState.getMouse(e);


### PR DESCRIPTION
I've noticed then when I drag a shape out of canvas's border event 'mousemove' keeps being triggered and when the mouse pointer gets back from same or any other side the shape 'jumps' right onto that position.
I think this was not intended by you so 'mouseleave' event can help by performing the same action like 'mouseup' does.

_P.S. there is no useCapture parameter set 'true' since 'mouseleave' doesn't bubble._